### PR TITLE
overhaul to how and where schema is located

### DIFF
--- a/main.py
+++ b/main.py
@@ -196,6 +196,8 @@ def get_args():
                 "table_secondary": table_secondary,
                 "tables": tables,
                 "personal_schema": yaml_config["personal_schema"],
+                "table_schema": 'null',
+                "diff_table_schema": 'null',
                 "key_columns": key_columns,
                 "comp_columns": args.comparison_columns,
                 "ignore_columns": args.ignore_columns,
@@ -264,7 +266,7 @@ def create_connection(args):
         db_url = args["database"]["db_path"]
     else:
         db_url = create_url()
-    db_url = "sqlite:///databases/Sqlite_test.db"
+
     try:
         engine = create_engine(db_url, echo=False, future=True)
         conn = engine.connect()

--- a/modules/reporting.py
+++ b/modules/reporting.py
@@ -149,8 +149,6 @@ class Reports:
         """ Outputs all reports gathered onto the CLI using Rich Tables to
             improve readability.
         """
-        # this needs to pull the unique schema for each table as it builds the table
-        # since the diff table will have a different schema from the other 2 tables
         def raw_tables():
             for table in self.args["table_info"]["tables"]:
                 try:
@@ -162,10 +160,16 @@ class Reports:
                         )
                     )
                     raw_table = Table(title=f"{table}")
-                    for col in self.args["table_info"]["personal_schema"]:
-                        raw_table.add_column(f"{col}_{table}", style="cyan", no_wrap=True)
+                    if table == self.args["table_info"]["tables"][-1]:
+                        for col in self.args["table_info"]["diff_table_schema"]:
+                            raw_table.add_column(f"{col}_{table}", style="cyan", no_wrap=True)
+                    else:
+                        for col in self.args["table_info"]["table_schema"]:
+                            raw_table.add_column(f"{col}_{table}", style="cyan", no_wrap=True)
+
                     for result in query:
                         raw_table.add_row(*map(str, result))
+
                 except OperationalError as e:
                     logging.critical(e)
                 except OperationalError as e:


### PR DESCRIPTION
- add class schemas to create_diff_table.py
  - class controls the creation of 2 different schemas, the comparison tables schema (which should be identical) and the diff_table schema (which is very likely different than the personal schema of the tables since the diff_table schema is based off of the compared columns used)
- fix reporting to show the correct column names