### PR TITLE
switched some args to store_true

### DIFF
--- a/modules/get_args.py
+++ b/modules/get_args.py
@@ -37,8 +37,8 @@ def get_args():
     # SEMI-REQUIRED ARGUMENTS
     parser.add_argument(
         "--configs",
-        choices=["y", "n"],
-        default=["n"],
+        action="store_true",
+        default=None,
         help="would you like to use the additional variables stored in cfg",
     )
     parser.add_argument(
@@ -76,14 +76,14 @@ def get_args():
     parser.add_argument(
         "-p",
         "--print_tables",
-        choices=["y", "n"],
-        default=["n"],
+        action="store_true",
+        default=None,
         help="prints the tables to the console, use at your own risk",
     )
     parser.add_argument(
         "--local_db",
-        choices=["y", "n"],
-        default=["n"],
+        action="store_true",
+        default=None,
         help="designates whether or not to use a local sourced database",
     )
 
@@ -101,7 +101,7 @@ def get_args():
                 return yaml_config
 
     def build_arg_dict(yaml_config):
-        if args.configs == "y":
+        if args.configs is True:
             db_type = yaml_config["db_type"]
             table_initial = yaml_config["table_initial"]
             table_secondary = yaml_config["table_secondary"]

--- a/modules/reporting.py
+++ b/modules/reporting.py
@@ -191,7 +191,7 @@ class Reports:
                 finally:
                     self.console.print(raw_table)
 
-        if self.args["system"]["print_tables"] == "y":
+        if self.args["system"]["print_tables"] is True:
             if (
                 Prompt.ask(
                     "[bold red]are you sure you want to print tables to the console? (y/n)"

--- a/table-differ.py
+++ b/table-differ.py
@@ -108,7 +108,7 @@ def create_connection(args):
             logging.info(f"[bold red] DATABASE URL:[/] {db_url}")
             return db_url
 
-    if args["system"]["local_db"] == "y":
+    if args["system"]["local_db"] is True:
         db_url = args["database"]["db_path"]
     else:
         db_url = create_url()


### PR DESCRIPTION
arguments:
local_db
print_tables
configs

all were using action=store which would store a 'y' or a 'n'.
This is annoying so they have been switched to action=store_true so that I can determine if the flag is true or false instead of a string.