### PR TITLE
psql cursor creation and variable clarification

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,5 +14,5 @@ diff_table: '__d__' # default to __diff_table))
 key_columns: ['id']
 schema_name: 'public'
 
-initial_table_name: 'origin'
-secondary_table_name: 'comparison'
+initial_table_alias: 'origin'
+secondary_table_alias: 'comparison'

--- a/modules/get_args.py
+++ b/modules/get_args.py
@@ -139,17 +139,23 @@ def get_args():
                 "db_path": db_path,
             },
             "table_info": {
-                "table_initial": table_initial,
-                "table_secondary": table_secondary,
-                "tables": tables,
+                "table_initial": table_initial,  # name of 1st table being queried
+                "table_secondary": table_secondary,  # name of 2nd table being queried
+                "diff_table": tables[-1],
+                "tables": tables,  # contains name of 1st, 2nd, and diff table
+                # these 4 rows in the dict contain the same info
                 "schema_name": yaml_config["schema_name"],
-                "table_schema": "null",
-                "diff_table_schema": "null",
+                "table_cols": "null",  # name of the columns in the 2 tables queried
+                "diff_table_cols": "null",  # name of the columns in the diff table
                 "key_columns": key_columns,
                 "comp_columns": args.comparison_columns,
                 "ignore_columns": args.ignore_columns,
-                "initial_table_name": yaml_config["initial_table_name"],
-                "secondary_table_name": yaml_config["secondary_table_name"],
+                "initial_table_alias": yaml_config[
+                    "initial_table_alias"
+                ],  # alias for 1st table
+                "secondary_table_alias": yaml_config[
+                    "secondary_table_alias"
+                ],  # alias for 2nd table
                 "except_rows": args.ex_rows,
             },
             "system": {

--- a/table-differ.py
+++ b/table-differ.py
@@ -84,9 +84,9 @@ def create_connection(args):
         db_url = None
         try:
             if args["database"]["db_type"] == "postgres":
-            ################### return built in for testing the psycopg2 connection
+                ################### return built in for testing the psycopg2 connection
                 return
-            ###################
+                ###################
                 with open(expanduser("~/.pgpass"), "r") as f:
                     host, port, database, user, password = f.read().split(":")
                 db_url = "postgresql+pyscopg2://{}:{}@{}:{}/{}".format(
@@ -117,18 +117,20 @@ def create_connection(args):
         else:
             db_url = create_url()
 
+        ########### temp psycopg2 connection ########################
         if args["database"]["db_type"] == "postgres":
             conn = psycopg2.connect(
-                    host = args["database"]["db_host"],
-                    database = args["database"]["db_name"],
-                    user = args["database"]["db_user"],
-                    port = args["database"]["db_port"],
-                    )
+                host=args["database"]["db_host"],
+                database=args["database"]["db_name"],
+                user=args["database"]["db_user"],
+                port=args["database"]["db_port"],
+            )
+        #############################################################
 
         try:
             # commented out for psycopg2 testing
-#            engine = create_engine(db_url, echo=False, future=True)
-#            conn = engine.connect()
+            #            engine = create_engine(db_url, echo=False, future=True)
+            #            conn = engine.connect()
             logging.info(f"[bold red]CURRENT CONNECTION:[/]  {conn}")
         except SQLAlchemyError as e:
             print(f"ERROR: {str(e)}")


### PR DESCRIPTION
Creation of psycopg2 cursor object for use in testing postgres capabilities.
Clarification and renaming of variables within config.yaml to be more readable and concise.

Primary changes include:
- change of variable name initial_table_name/secondary_table_name --> initial_table_alias/secondary_table_alias
- change of variable name table_schema --> table_cols
- creation of psycopg2 cursor object
- psql col names in GetSchema built into for loop to reduce code
- in some places the name of the diff_table was pulled from args["table_info"]["tables"][-1] or args["table_info"]["tables"][2]. Both of these are bad and have been replaced with just calling the args["table_info"]["diff_table"]
- added clarifying comments into config.yaml